### PR TITLE
Add GitHub issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,106 @@
+name: Bug Report
+description: Report a bug or unexpected behavior in LOOM
+labels: ["bug"]
+body:
+  - type: textarea
+    id: summary
+    attributes:
+      label: Bug summary
+      description: One-sentence description of the bug.
+      placeholder: "`loom new` fails when ..."
+    validations:
+      required: true
+
+  - type: dropdown
+    id: command
+    attributes:
+      label: Command
+      description: Which `loom` command triggered the bug?
+      options:
+        - loom init
+        - loom new
+        - loom add
+        - loom remove
+        - loom down
+        - loom list
+        - loom status
+        - loom exec
+        - loom shell
+        - loom save
+        - loom open
+        - loom registry
+        - TUI
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: Numbered steps to reliably reproduce the bug.
+      placeholder: |
+        1. Run `loom new test-ws`
+        2. Select repos X and Y
+        3. Observe error ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: What should have happened?
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+      description: What actually happened? Include the full error message, panic output, or unexpected behavior.
+      placeholder: |
+        ```
+        Error: ...
+        ```
+    validations:
+      required: true
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: |
+        Please provide:
+        - OS and version
+        - Git version (`git --version`)
+        - LOOM version (`loom --version`)
+        - Rust version if building from source (`rustc --version`)
+      placeholder: |
+        - OS: macOS 15.3
+        - Git: 2.47.0
+        - LOOM: 0.1.0
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: modules
+    attributes:
+      label: Modules likely affected
+      description: Which crate modules do you think are involved? (Check all that apply)
+      options:
+        - label: "`workspace`"
+        - label: "`git`"
+        - label: "`config`"
+        - label: "`manifest`"
+        - label: "`sync`"
+        - label: "`tui`"
+        - label: "`agent`"
+        - label: "`registry`"
+        - label: "`cli`"
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional context
+      description: Logs, screenshots, config snippets, or workarounds.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Question or Discussion
+    url: https://github.com/subotic/loom/discussions
+    about: Ask questions or start a discussion (not a bug or feature request)

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,99 @@
+name: Feature Request
+description: Propose a new feature or enhancement for LOOM
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: One-paragraph description of the feature.
+      placeholder: "LOOM should support ..."
+    validations:
+      required: true
+
+  - type: textarea
+    id: motivation
+    attributes:
+      label: Motivation
+      description: Why is this needed? What problem does it solve or what workflow does it enable?
+      placeholder: "When I try to ... I run into ... because ..."
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: commands
+    attributes:
+      label: Commands affected
+      description: Which `loom` commands are involved? (Check all that apply)
+      options:
+        - label: "`loom init`"
+        - label: "`loom new`"
+        - label: "`loom add`"
+        - label: "`loom remove`"
+        - label: "`loom down`"
+        - label: "`loom list`"
+        - label: "`loom status`"
+        - label: "`loom exec`"
+        - label: "`loom shell`"
+        - label: "`loom save`"
+        - label: "`loom open`"
+        - label: "`loom registry`"
+        - label: "TUI"
+        - label: "New command"
+
+  - type: checkboxes
+    id: modules
+    attributes:
+      label: Modules affected
+      description: Which crate modules are likely touched? (Check all that apply)
+      options:
+        - label: "`workspace`"
+        - label: "`git`"
+        - label: "`config`"
+        - label: "`manifest`"
+        - label: "`sync`"
+        - label: "`tui`"
+        - label: "`agent`"
+        - label: "`registry`"
+        - label: "`cli`"
+
+  - type: textarea
+    id: proposed-behavior
+    attributes:
+      label: Proposed behavior
+      description: |
+        How should the feature work? Include CLI examples, expected output, and edge cases.
+      placeholder: |
+        ```
+        $ loom new my-workspace
+        # expected output ...
+        ```
+
+        Edge cases:
+        - ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: acceptance-criteria
+    attributes:
+      label: Acceptance criteria
+      description: Checklist of conditions that must be true when this feature is complete.
+      placeholder: |
+        - [ ] ...
+        - [ ] ...
+        - [ ] Tests pass
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Other approaches you considered and why this one is preferred.
+
+  - type: textarea
+    id: related
+    attributes:
+      label: Related issues / specs
+      description: Links to PRD sections, other issues, or specs.


### PR DESCRIPTION
## Summary

- Add structured form-based issue templates for feature requests and bug reports
- Templates include command/module checkboxes matching LOOM's architecture, making issues actionable for both humans and the Claude Code agent workflow (`claude.yml`)
- Disable blank issues to encourage structured submissions

## Test plan

- [ ] Visit https://github.com/subotic/loom/issues/new/choose and verify both templates appear
- [ ] Fill out and submit a test feature request — verify rendered markdown is clean
- [ ] Fill out and submit a test bug report — verify rendered markdown is clean
- [ ] Verify blank issues are disabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)