### PR TITLE
ci(release): add commit_parsers to filter changelog sections

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -8,6 +8,21 @@ changelog_update = false
 # Check for semver-breaking changes
 semver_check = true
 
+[changelog]
+protect_breaking_commits = true
+sort_commits = "oldest"
+
+commit_preprocessors = [
+    { pattern = '\\(#([0-9]+)\\)', replace = "([#${1}](https://github.com/subotic/loom/pull/${1}))" },
+]
+
+commit_parsers = [
+    { message = "^feat", group = "Added" },
+    { message = "^fix", group = "Fixed" },
+    { message = "^perf", group = "Performance" },
+    { message = "^.*", skip = true },
+]
+
 [[package]]
 name = "loom-cli"
 # loom-cli owns the unified root changelog


### PR DESCRIPTION
## Motivation
The release-plz changelog includes an "Other" section with noise commits (ci, chore, refactor, etc.) that aren't useful to users.

## Summary
- Add `[changelog]` section to `release-plz.toml` with custom `commit_parsers`
- Only `feat:` → Added, `fix:` → Fixed, `perf:` → Performance appear in changelog
- All other commit types are skipped (no "Other" section)
- Breaking commits are always included regardless of type
- PR references are linkified automatically

## Test Plan
- [ ] Merge, wait for release-plz to regenerate release PR
- [ ] Verify changelog has only "Added" and "Fixed" sections (no "Other")
- [ ] Verify loom-core commits appear via `changelog_include`

🤖 Generated with [Claude Code](https://claude.com/claude-code)