### PR TITLE
docs: use one Closes keyword per issue in PR template

### DIFF
--- a/docs/commit-conventions.md
+++ b/docs/commit-conventions.md
@@ -81,6 +81,7 @@ not found in the workspace root.
 
 ```
 Closes #<issue-number>
+Closes #<issue-number>
 
 ## Motivation
 Why this work was needed. What problem it solves for users.
@@ -107,6 +108,22 @@ actionable -- not just "this is hard" but "do X instead of Y".
 
 ## Test Plan
 - [ ] verification steps
+```
+
+### Closing issues
+
+Use one `Closes` keyword per issue, each on its own line. Do NOT
+comma-separate multiple issues on one line — GitHub may silently
+skip some of them.
+
+```
+# Good
+Closes #39
+Closes #40
+Closes #41
+
+# Bad — GitHub may not close all of them
+Closes #39, #40, #41
 ```
 
 ### Why this format matters


### PR DESCRIPTION
Closes #71

## Motivation

PR #69 used `Closes #39, #40, #41, #43, ...` on one line. GitHub closed most
but silently skipped #43, #49, and #50. The comma-separated format is unreliable.

## Summary

- Update PR description template in `docs/commit-conventions.md` to show one `Closes` per line
- Add a "Closing issues" section explaining the correct format with good/bad examples

## Test Plan

- [x] Verify template shows separate lines for each issue

🤖 Generated with [Claude Code](https://claude.ai/code)