### PR TITLE
ci(release): fix duplicate tag error in multi-crate workspace

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,8 +1,9 @@
 [workspace]
 # Let cargo-dist create the GitHub Release (it attaches binaries)
 git_release_enable = false
-# Tag format matching cargo-dist expectations
-git_tag_name = "v{{ version }}"
+# Disable tagging at workspace level — only loom-cli creates the single tag
+# (prevents "Reference already exists" when both crates share the same tag name)
+git_tag_enable = false
 # Disable per-package changelogs by default
 changelog_update = false
 # Check for semver-breaking changes
@@ -28,11 +29,12 @@ commit_parsers = [
 
 [[package]]
 name = "loom-cli"
-# loom-cli owns the unified root changelog
+# loom-cli owns the unified root changelog and the single git tag
 changelog_update = true
 changelog_path = "./CHANGELOG.md"
-# Include loom-core commits in the same changelog
 changelog_include = ["loom-core"]
+git_tag_enable = true
+git_tag_name = "v{{ version }}"
 version_group = "loom"
 
 [[package]]


### PR DESCRIPTION
Closes #74

## Motivation

The v0.2.0 release failed because release-plz tried to create the `v0.2.0` tag twice — once for `loom-core` and once for `loom-cli`. The second attempt got "Reference already exists". This also caused `loom-cli` to not be published to crates.io.

## Summary

- Disable `git_tag_enable` at workspace level
- Enable it only on `loom-cli` (the primary package that owns the tag)
- `loom-core` inherits the disabled default — no tag created for it

## References

- [release-plz single-tag docs](https://release-plz.ieni.dev/docs/extra/single-tag)
- [release-plz/release-plz#2292](https://github.com/release-plz/release-plz/issues/2292) — same issue reported by another multi-crate workspace

## Test Plan

- [x] Config matches the documented single-tag pattern
- [ ] Next release creates only one tag and publishes both crates