### PR TITLE
build: add [profile.dist] required by cargo-dist 0.31.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,3 +61,8 @@ self_update = { version = "0.43", default-features = false, features = [
 
 # Testing (used as dev-dependency in crates)
 insta = "1.42"
+
+# cargo-dist build profile
+[profile.dist]
+inherits = "release"
+lto = "thin"

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,8 +1,9 @@
 [workspace]
 # Let cargo-dist create the GitHub Release (it attaches binaries)
 git_release_enable = false
-# Tag format matching cargo-dist expectations
-git_tag_name = "v{{ version }}"
+# Disable tagging at workspace level — only loom-cli creates the single tag
+# (prevents "Reference already exists" when both crates share the same tag name)
+git_tag_enable = false
 # Disable per-package changelogs by default
 changelog_update = false
 # Check for semver-breaking changes
@@ -28,11 +29,12 @@ commit_parsers = [
 
 [[package]]
 name = "loom-cli"
-# loom-cli owns the unified root changelog
+# loom-cli owns the unified root changelog and the single git tag
 changelog_update = true
 changelog_path = "./CHANGELOG.md"
-# Include loom-core commits in the same changelog
 changelog_include = ["loom-core"]
+git_tag_enable = true
+git_tag_name = "v{{ version }}"
 version_group = "loom"
 
 [[package]]


### PR DESCRIPTION
## Motivation

The v0.2.0 release build failed on all 4 targets with `error: profile 'dist' is not defined`. cargo-dist 0.31.0 expects a `[profile.dist]` in Cargo.toml for release builds.

## Summary

- Add `[profile.dist]` inheriting from `release` with `lto = "thin"` for smaller binaries

## Test Plan

- [ ] Re-trigger release workflow after merge: `gh workflow run release.yml -f tag=v0.2.0`